### PR TITLE
Add userId to AuthContext and protect self-delete

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -7,6 +7,7 @@ import { getCurrentProfile } from '@/services/user_service';
 interface AuthContextType{
     isAuthenticated: boolean;
     isAdmin: boolean;
+    userId: string | null;
     userStats: UserStats | null;
     login: (email: string, password: string) => Promise<boolean>;
     loginWithGoogle: () => void;
@@ -22,6 +23,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode })=>{
     //Initial state
     const [isAuthenticated, setIsAuthenticated] = useState<boolean>(!!localStorage.getItem('token'));
     const [isAdmin, setIsAdmin] = useState<boolean>(localStorage.getItem('userRole') === 'admin');
+    const [userId, setUserId] = useState<string | null>(localStorage.getItem('userId'));
     const [userStats, setUserStats] = useState<UserStats | null>(null);
     const [error, setError] = useState<string | null>(null);
 
@@ -30,6 +32,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode })=>{
         const profile = await getCurrentProfile();
         const isAdminUser = profile.role === 'admin';
         setIsAdmin(isAdminUser);
+        setUserId(profile.id);
+        localStorage.setItem('userId', profile.id);
         if (isAdminUser) {
             localStorage.setItem('userRole', 'admin');
         } else {
@@ -67,8 +71,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode })=>{
     const logout = useCallback(() =>{
         localStorage.removeItem('token');
         localStorage.removeItem('userRole');
+        localStorage.removeItem('userId');
         setIsAuthenticated(false);
         setIsAdmin(false);
+        setUserId(null);
         setUserStats(null);
         setError(null);
     }, []);
@@ -79,14 +85,16 @@ export const AuthProvider = ({ children }: { children: React.ReactNode })=>{
         if (storedToken) {
             setIsAuthenticated(true);
             setIsAdmin(localStorage.getItem('userRole') === 'admin');
+            setUserId(localStorage.getItem('userId'));
         } else {
             setIsAuthenticated(false);
             setIsAdmin(false);
+            setUserId(null);
         }
     }, []);
 
     return (
-        <AuthContext.Provider value={{ isAuthenticated, isAdmin, userStats, setUserStats, login, loginWithGoogle, handleOAuthToken, logout, error }}>
+        <AuthContext.Provider value={{ isAuthenticated, isAdmin, userId, userStats, setUserStats, login, loginWithGoogle, handleOAuthToken, logout, error }}>
             {children}
         </AuthContext.Provider>
     );

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -22,7 +22,7 @@ function getAvatarColor(seed: string): { bg: string; text: string } {
 }
 
 const AdminDashboard = () => {
-    const { logout } = useAuth();
+    const { logout, userId } = useAuth();
     const navigate = useNavigate();
     const [users, setUsers] = useState<UserProfile[]>([]);
     const [loading, setLoading] = useState(true);
@@ -30,18 +30,26 @@ const AdminDashboard = () => {
     const [searchQuery, setSearchQuery] = useState("");
 
     const filteredUsers = useMemo(() => {
-        if (!searchQuery.trim()) return users;
-        const q = searchQuery.toLowerCase();
-        return users.filter(u => {
-            const fullName = `${u.first_name || ''} ${u.last_name || ''}`.trim().toLowerCase();
-            return (
-                u.first_name?.toLowerCase().includes(q) ||
-                u.last_name?.toLowerCase().includes(q) ||
-                u.email?.toLowerCase().includes(q) ||
-                fullName.includes(q)
-            );
+        let result = users;
+        if (searchQuery.trim()) {
+            const q = searchQuery.toLowerCase();
+            result = users.filter(u => {
+                const fullName = `${u.first_name || ''} ${u.last_name || ''}`.trim().toLowerCase();
+                return (
+                    u.first_name?.toLowerCase().includes(q) ||
+                    u.last_name?.toLowerCase().includes(q) ||
+                    u.email?.toLowerCase().includes(q) ||
+                    fullName.includes(q)
+                );
+            });
+        }
+        // Put current admin first in the list
+        return result.sort((a, b) => {
+            if (a.id === userId) return -1;
+            if (b.id === userId) return 1;
+            return 0;
         });
-    }, [users, searchQuery]);
+    }, [users, searchQuery, userId]);
 
     // Modal state
     const [showModal, setShowModal] = useState(false);
@@ -95,6 +103,7 @@ const AdminDashboard = () => {
             await deleteUser(userToDelete.id);
             const updatedUsers = await getAllUsers();
             setUsers(updatedUsers);
+            toast.success('User deleted successfully');
             setShowDeleteModal(false);
             setUserToDelete(null);
         } catch (err) {
@@ -108,6 +117,10 @@ const AdminDashboard = () => {
     };
 
     const openDeleteModal = (user: UserProfile) => {
+        if (user.id === userId) {
+            toast.error('You cannot delete your own account');
+            return;
+        }
         setUserToDelete(user);
         setShowDeleteModal(true);
     };


### PR DESCRIPTION
Expose and persist the current user's id via AuthContext (userId) initialized from localStorage and set when fetching profile; remove it on logout and include it in the provider value. Update AdminDashboard to use userId: only run the filter when a search query exists, sort results to place the current admin first, prevent deleting the logged-in admin (show error toast), and show a success toast after deletion. Also added userId to memo dependencies.